### PR TITLE
Add github action for running tests that require a database

### DIFF
--- a/.env.ci
+++ b/.env.ci
@@ -1,0 +1,6 @@
+DATABASE_ENGINE=postgresql
+DATABASE_NAME=voterguide
+DATABASE_USERNAME=vguser
+DATABASE_PASSWORD=supersecretdbpassword
+DATABASE_HOST=localhost
+DATABASE_PORT=5432

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,35 @@
+name: Run Tests
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test_with_db:
+    runs-on: ubuntu-latest
+    services:
+      db:
+        image: postgres:14-alpine
+        env:
+          POSTGRES_USER: vguser
+          POSTGRES_PASSWORD: supersecretdbpassword
+          POSTGRES_DB: voterguide
+        ports:
+          - 5432:5432
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build API image
+        run: docker build -t api:ci .
+
+      - name: Run tests
+        run: docker run -e DJANGO_SECRET_KEY=${{ secrets.DJANGO_SECRET_KEY }} --env-file .env.ci --network host api:ci pytest


### PR DESCRIPTION
Adds a github action to build and run pytest in an API docker container. Once tests are added that do not require a database, another job should be added to the workflow to allow for quicker tests with less setup to run in parallel.